### PR TITLE
Add null check to window.open

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # R8A2 Password Generator
 
-A little wbesite that generates the Rundown 8 A2 secret terminal password for any week.  
+A little website that generates the Rundown 8 A2 secret terminal password for any week.  
 
 This was actually quite a pain to get working just because JS numbers are just 'numbers';  
 Getting integer overflow to work properly, like how it's abused by the hashing algorithm used in GTFO, was quite the journey.

--- a/terminal.js
+++ b/terminal.js
@@ -50,13 +50,13 @@ const commands = {
 
         if (program === "DENOFWOLVES.EXE") {
             this.echo("Executing '"+program+"'");
-            window.open("https://www.denofwolves.com/", '_blank').focus();
+            OpenUrlInNewTab("https://www.denofwolves.com/");
             return;
         }
 
         if (program === "GTFO.EXE") {
             this.echo("Executing '"+program+"'");
-            window.open("https://gtfothegame.com/", '_blank').focus();
+            OpenUrlInNewTab("https://www.gtfothegame.com/");
             return;
         }
 
@@ -164,6 +164,15 @@ const commands = {
         this.echo("");
     }
 };
+
+function OpenUrlInNewTab(url) {
+    let win = window.open(url, '_blank');
+    if (win != null) {
+        win.focus();
+    } else {
+        $('#terminal').terminal().error("PERMISSION OVERRIDE NEEDED TO ACCESS REMOTE SYSTEM.");
+    }
+}
 
 function SetupTerminal() {
     $('#terminal').terminal(commands, {


### PR DESCRIPTION
Currently, if the window.open() call returns null (such as if browser settings blocked the pop up window), it will throw an error.

This PR fixes that.

Example: 
![image](https://github.com/AuriRex/A2Password/assets/37639973/79ac3e40-d523-4e20-a867-1a0ea1221cf1)
